### PR TITLE
feat: add installation instructions for all frameworks and flavors

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -48,8 +48,9 @@ module.exports = {
     // },
     repo: 'windicss/windicss',
     logo: '/assets/logo.svg',
-    docsDir: 'docs',
+    docsDir: '.',
     docsBranch: 'main',
+    docsRepo: 'windicss/docs',
     editLinks: true,
     editLinkText: 'Suggest changes to this page',
 
@@ -100,7 +101,15 @@ module.exports = {
             { text: 'Configuration', link: '/guide/configuration' },
             { text: 'Directives', link: '/guide/directives' },
             { text: 'Plugins', link: '/guide/plugins' },
+          ],
+        },
+        {
+          text: 'Installation',
+          children: [
             { text: 'Migration', link: '/guide/migration' },
+            { text: 'Svelte', link: '/guide/svelte' },
+            { text: 'Vite', link: '/guide/vite' },
+            { text: 'Vue', link: '/guide/vue' },
           ],
         },
         {
@@ -108,7 +117,6 @@ module.exports = {
           children: [
             { text: 'CLI', link: '/guide/cli' },
             { text: 'Modes', link: '/guide/modes' },
-            { text: 'Svelte', link: '/guide/svelte' },
             { text: 'The Story', link: '/guide/story' },
           ],
         },

--- a/guide/cli.md
+++ b/guide/cli.md
@@ -1,4 +1,4 @@
-### Command Line Interface ⌨️
+# Command Line Interface ⌨️
 
 You can install the CLI by running:
 

--- a/guide/index.md
+++ b/guide/index.md
@@ -14,11 +14,11 @@ If you are looking for utilities, check out the [utilities reference].
 
 - [__CLI__](/guide/cli)
 
-- Svelte: <kbd>[svelte-windicss-preprocess](https://github.com/windicss/svelte-windicss-preprocess)</kbd>
+- Svelte: <kbd>[svelte-windicss-preprocess](/guide/svelte)</kbd>
 
-- Vite: <kbd>[vite-plugin-windicss](https://github.com/windicss/vite-plugin-windicss)</kbd>
+- Vite: <kbd>[vite-plugin-windicss](/guide/vite)</kbd>
 
-- Vue: <kbd>[vue-windicss-preprocess](https://github.com/windicss/vue-windicss-preprocess)</kbd>
+- Vue: <kbd>[vue-windicss-preprocess](/guide/vue)</kbd>
 
 - React: Coming soon
 

--- a/guide/introduction.md
+++ b/guide/introduction.md
@@ -3,6 +3,7 @@
 [tailwind css]: https://tailwindcss.com/docs
 [autoprefixer]: https://autoprefixer.github.io/
 [additional features]: /guide/svelte
+[video comparison]: https://twitter.com/antfu7/status/1361398324587163648
 
 # Introduction
 
@@ -18,7 +19,7 @@ Everything you know and love about [Tailwind CSS], plus:
 
 #### ⚡️ Speed
 
-It detects utilities and directives in your CSS, and process them on demand, which greatly improves the compilation speed. Windi only loads the CSS you use, no purging required!
+It detects utilities and directives in your CSS, and process them on demand, which [greatly improves][video comparison] the compilation speed. Windi only loads the CSS you use, no purging required!
 
 #### 🔌 Compatibility
 

--- a/guide/migration.md
+++ b/guide/migration.md
@@ -1,10 +1,17 @@
 [auto]: /utilities/auto
+[design]: /guide/modes
 
 # Migrating to Windi CSS
 
-If you are already using Tailwind CSS for your Vite app, you can follow these instructions to migrate your installation.
+While Windi CSS aims to be compatible with Tailwind CSS, there are some slight differences in configuration.
 
-## `package.json`
+Some options are no longer necessary, because of its [design].
+
+## From Tailwind CSS
+
+If you are using Tailwind CSS with the PostCSS plugin, you can follow these instructions to migrate your installation.
+
+### `package.json`
 
 Some of your dependencies are no longer required, you can remove them if they were only needed for Tailwind CSS.
 
@@ -15,7 +22,7 @@ Some of your dependencies are no longer required, you can remove them if they we
 + "windicss": "*"
 ```
 
-## Base Styles
+### Base Styles
 
 You can now remove the Tailwind CSS imports from your css entry.
 
@@ -27,7 +34,7 @@ You can now remove the Tailwind CSS imports from your css entry.
 
 These are now handled automatically by Windi CSS.
 
-## `tailwind.config.js`
+### `tailwind.config.js`
 
 Since all variants are [automatically enabled][auto], `purge` is no longer needed.
 
@@ -65,25 +72,7 @@ module.exports = {
 }
 ```
 
-## `vite.config.js`
-
-Add this plugin into your configuration.
-
-```ts
-// vite.config.js
-import WindiCSS from 'vite-plugin-windicss'
-
-export default {
-  plugins: [
-    /* ... */
-    ...WindiCSS({
-      safelist: 'prose prose-sm m-auto'
-    })
-  ],
-};
-```
-
-## Cleanup (optional)
+### Cleanup (optional)
 
 The following files can be removed if you don't use their other features.
 

--- a/guide/svelte.md
+++ b/guide/svelte.md
@@ -1,10 +1,239 @@
 [utility groups]: /guide/introduction.html#🎳-utility-groups
+[svelte-windicss-preprocess]: https://github.com/windicss/svelte-windicss-preprocess
+[migration]: /guide/migration
 
-# Additional Features in Svelte  ⚡️
+# Using Windi CSS in Svelte
+
+<kbd>[svelte-windicss-preprocess]</kbd> provides simple integration for Windi CSS in Svelte and Sapper.
+
+> Now we have a great playground, you can [try it online](https://voorjaar.github.io/svelte-windicss-preprocess/) before installing it.
+
+## Installation 💿
+
+Add the package:
+
+```sh
+npm install svelte-windicss-preprocess --save-dev
+```
+
+::: tip Migrating
+If migrating from Tailwind CSS, also check out the [_Migration_ section][migration]
+:::
+
+## Configuration ⚙️
+
+Add <kbd>[svelte-windicss-preprocess]</kbd> to your Rollup or Webpack configuration.
+
+If using:
+
+### Vanilla Svelte
+
+Add <kbd>[svelte-windicss-preprocess]</kbd> to your `rollup.config.js`.
+
+```js
+// rollup.config.js
+// ...
+export default {
+  // ...
+  plugins: [
+    svelte({
+      // svelte-windicss-preprocess
+      preprocess: require('svelte-windicss-preprocess').preprocess({
+        config: 'tailwind.config.js', // tailwind config file path (optional)
+        compile: true,          // false: interpretation mode; true: compilation mode
+        prefix: 'windi-',       // set compilation mode style prefix
+        globalPreflight: true,  // set preflight style is global or scoped
+        globalUtility: true,    // set utility style is global or scoped
+      })
+      // ...
+    }),
+  ]
+  // ...
+}
+```
+
+### Sveltekit
+
+Add <kbd>[svelte-windicss-preprocess]</kbd> to your `svelte.config.cjs`.
+
+> For now, sveltekit has an issue of setting the preprocessor. Make sure your `snowpack.config.cjs` is consistent with our [example](https://github.com/voorjaar/svelte-windicss-preprocess/blob/v2.1.0/example/svelte-next/snowpack.config.cjs) before setting.
+
+```js
+// svelte.config.cjs
+module.exports = {
+  preprocess: require("svelte-windicss-preprocess").preprocess({
+    // uncomment this, if you need a config file
+    // config: 'tailwind.config.js',
+    compile: false,
+    prefix: "windi-",
+    globalPreflight: true,
+    globalUtility: true,
+  }),
+  kit: {
+    adapter: "@sveltejs/adapter-node",
+    target: "#svelte",
+  },
+};
+```
+
+with Typescript
+
+```js
+// svelte.config.cjs
+const sveltePreprocess = require('svelte-preprocess');
+module.exports = {
+  preprocess: [
+    sveltePreprocess.typescript(),
+    require('svelte-windicss-preprocess').preprocess({
+      // uncomment this, if you need a config file
+      // config: 'tailwind.config.js',
+      compile: false,
+      prefix: 'windi-',
+      globalPreflight: true,
+      globalUtility: true,
+    }),
+  ],
+  kit: {
+    adapter: '@sveltejs/adapter-node',
+    target: '#svelte'
+  }
+};
+
+```
+
+### Sapper(rollup)
+
+Add <kbd>[svelte-windicss-preprocess]</kbd> to your `rollup.config.js`.
+
+```js
+// rollup.config.js
+// ...
+export default {
+  // ...
+  client: {
+    input: config.client.input(),
+    output: config.client.output(),
+    plugins: [
+      // ...
+      svelte({
+        // svelte-windicss-preprocess
+        preprocess: require('svelte-windicss-preprocess').preprocess({
+          config: 'tailwind.config.js',     // tailwind config file path
+          compile: true,                    // false: interpretation mode; true: compilation mode
+          prefix: 'windi-',                 // set compilation mode style prefix
+          globalPreflight: true,            // set preflight style is global or scoped
+          globalUtility: true,              // set utility style is global or scoped
+        }),
+        compilerOptions: {
+          // ...
+        }
+      }),
+      // ...
+    ]
+  // ...
+  }
+  server: {
+    input: config.server.input(),
+    output: config.server.output(),
+    plugins: [
+      // ...
+      svelte({
+        // svelte-windicss-preprocess
+        preprocess: require('svelte-windicss-preprocess').preprocess({
+          config: 'tailwind.config.js',      // tailwind config file path
+          compile: true,                     // false: interpretation mode; true: compilation mode
+          prefix: 'windi-',                  // set compilation mode style prefix
+          globalPreflight: true,             // set preflight style is global or scoped
+          globalUtility: true,               // set utility style is global or scoped
+        }),
+        compilerOptions: {
+          // ...
+        },
+      }),
+      // ...
+    ]
+  }
+  // ...
+}
+```
+
+### Sapper(webpack)
+
+Add <kbd>[svelte-windicss-preprocess]</kbd> to your `webpack.config.js`.
+
+```js
+// webpack.config.js
+module.exports = {
+  client: {
+    // ...
+    module: {
+      rules: [
+        {
+          test: /\.(svelte|html)$/,
+          use: {
+            loader: 'svelte-loader',
+            options: {
+              // ... other options
+              // svelte-windicss-preprocess
+              preprocess: require('svelte-windicss-preprocess').preprocess({
+                config: 'tailwind.config.js',    // tailwind config file path
+                compile: true,                   // false: interpretation mode; true: compilation mode
+                prefix: 'windi-',                // set compilation mode style prefix
+                globalPreflight: true,           // set preflight style is global or scoped
+                globalUtility: true,             // set utility style is global or scoped
+              })
+            }
+          }
+        },
+        // ...
+      ]
+    },
+  },
+
+  server: {
+    // ...
+    module: {
+      rules: [
+        {
+          test: /\.(svelte|html)$/,
+          use: {
+            loader: 'svelte-loader',
+            options: {
+              // ... other options
+              // svelte-windicss-preprocess
+              preprocess: require('svelte-windicss-preprocess').preprocess({
+                config: 'tailwind.config.js',     // tailwind config file path
+                compile: true,                    // false: interpretation mode; true: compilation mode
+                prefix: 'windi-',                 // set compilation mode style prefix
+                globalPreflight: true,            // set preflight style is global or scoped
+                globalUtility: true,              // set utility style is global or scoped
+              })
+            }
+          }
+        },
+        // ...
+      ]
+    },
+  }
+}
+```
+
+### Setup VSCode Extension
+
+If you are using `Svelte for VS Code` vscode extension, I believe most people are using it. You will need to add `"vetur.validation.style": false` to your configuration file.
+
+Hit `ctrl-shift-p` or `cmd-shift-p` on mac, type open settings, and select `Preferences: Open Settings (JSON)`. Add `"vetur.validation.style": false` to `settings.json` then save it.
+
+Then you will need to tell svelte-vscode to **restart the svelte language server** in order to pick up a new configuration.
+
+Hit `ctrl-shift-p` or `cmd-shift-p` on mac, type svelte restart, and select `Svelte: Restart Language Server`. Any errors you were seeing should now go away and you're now all set up!
+
+
+## Additional Features in Svelte  ⚡️
 
 <kbd>[svelte-windicss-preprocess](https://github.com/windicss/svelte-windicss-preprocess)</kbd> also supports the following features:
 
-## Variant Attributes
+### Variant Attributes
 
 You can apply several utilities for the same variant by using HTML attributes.
 

--- a/guide/vite.md
+++ b/guide/vite.md
@@ -1,0 +1,49 @@
+[video comparison]: https://twitter.com/antfu7/status/1361398324587163648
+[vite-plugin-windicss]: https://github.com/windicss/vite-plugin-windicss
+[migration]: /guide/migration
+
+# Using Windi CSS in Vite.js
+
+<kbd>[vite-plugin-windicss]</kbd> provides simple integration for Windi CSS in Vite.
+
+Check this [video comparison] with the PostCSS plugin for Tailwind CSS.
+
+## Installation 💿
+
+Add the package:
+
+```
+npx ni vite-plugin-windicss -D
+```
+
+Then, install the plugin in your Vite configuration:
+
+```ts
+// vite.config.js
+import WindiCSS from 'vite-plugin-windicss'
+
+export default {
+  plugins: [
+    WindiCSS(),
+  ],
+}
+```
+
+And finally, import `windi.css` in your Vite entries:
+
+```
+// main.js
+import 'windi.css'
+```
+
+That's it! Build your app as you would do with Tailwind CSS, but with a faster dev experience! ⚡️
+
+::: tip Migrating
+If migrating from Tailwind CSS, also check out the [_Migration_ section][migration]
+:::
+
+## Configuration ⚙️
+
+Check [options.ts](https://github.com/windicss/vite-plugin-windicss/blob/main/src/box/options.ts#L9-L103) for configuration reference specific to <kbd>[vite-plugin-windicss]</kbd>.
+
+See [./example](./example) or [`Vitesse@feat/windicss`](https://github.com/antfu/vitesse/tree/feat/windicss) for an example.

--- a/guide/vue.md
+++ b/guide/vue.md
@@ -1,0 +1,115 @@
+[video comparison]: https://twitter.com/antfu7/status/1361398324587163648
+[vite-plugin-windicss]: https://github.com/windicss/vite-plugin-windicss
+[migration]: /guide/migration
+[vue-windicss-preprocess]: https://github.com/windicss/vue-windicss-preprocess
+
+# Using Windi CSS with Vue
+
+If using Vite.js, check [this page instead](/guide/vite).
+
+<kbd>[vue-windicss-preprocess]</kbd> is a Vue loader for Windi CSS.
+
+## Installation 💿
+
+Install the package:
+
+```sh
+npx ni vue-windicss-preprocess -D
+```
+
+::: tip Migrating
+If migrating from Tailwind CSS, also check out the [_Migration_ section][migration]
+:::
+
+## Configuration ⚙️
+
+Add <kbd>[vue-windicss-preprocess]</kbd> to your Webpack configuration.
+
+If you are using:
+
+### Vue CLI
+
+Add the loader to your Webpack configuration:
+
+```js
+// vue.config.js
+module.exports = {
+  configureWebpack: (config) => {
+    config.module.rules.push({
+      test: /\.vue$/,
+      use: [{
+        loader: 'vue-windicss-preprocess',
+        options: {
+          config: "tailwind.config.js",  // tailwind config file path (optional)
+          compile: false,                // false: interpretation mode; true: compilation mode
+          globalPreflight: true,         // set preflight style is global or scoped
+          globalUtility: true,           // set utility style is global or scoped
+          prefix: 'windi-'               // set compilation mode style prefix
+        }
+      }]
+    })
+  }
+}
+```
+
+### Vanilla Webpack
+
+Add the loader to your Webpack configuration:
+
+```js
+// webpack.config.js
+module.exports = {
+  module: {
+    rules: [
+      // ... other rules omitted
+      {
+        test: /\.vue$/,
+        use: [{
+          loader: 'vue-windicss-preprocess',
+          options: {
+            config: "tailwind.config.js",  // tailwind config file path (optional)
+            compile: false,                // false: interpretation mode; true: compilation mode
+            globalPreflight: true,         // set preflight style is global or scoped
+            globalUtility: true,           // set utility style is global or scoped
+            prefix: 'windi-'               // set compilation mode style prefix
+          }
+        }]
+      }
+    ]
+  },
+  // plugin omitted
+}
+```
+
+### Nuxt
+
+Add the loader to your `nuxt.config.js`
+
+```js
+// nuxt.config.js
+export default {
+  // ... other configurations omitted
+  // Build Configuration (https://go.nuxtjs.dev/config-build)
+  build: {
+    extend(config) {
+      config.module.rules.push({
+        test: /\.vue$/,
+        loader: 'vue-windicss-preprocess',
+        options: {
+          config: "tailwind.config.js",  // tailwind config file path (optional)
+          compile: false,                // false: interpretation mode; true: compilation mode
+          globalPreflight: true,         // set preflight style is global or scoped
+          globalUtility: true,           // set utility style is global or scoped
+          prefix: 'windi-'               // set compilation mode style prefix
+        }
+      })
+    }
+  }
+}
+```
+
+### Vetur in VSCode
+
+Add `"vetur.validation.style": false` to your configuration file.
+
+Hit `ctrl-shift-p` or `cmd-shift-p` on mac, type open settings, and select `Preferences: Open Settings (JSON)`. Add `"vetur.validation.style": false` to `settings.json` then save it.


### PR DESCRIPTION
### Description 📖 

This pull request adds installation instructions for all available packages, extracted from their respective READMEs.

Usage instructions should probably live on a common page, since it's very similar on all frameworks.

Also, made the _Migration_ section framework-agnostic; linking to it from all installation pages.

### Screenshots 📷 

<img width="1426" alt="Screen Shot 2021-02-16 at 10 30 31" src="https://user-images.githubusercontent.com/1158253/108069384-12c53a80-7042-11eb-943d-620fa52f46fc.png">
<img width="1424" alt="Screen Shot 2021-02-16 at 10 19 09" src="https://user-images.githubusercontent.com/1158253/108069401-1658c180-7042-11eb-8ffb-aabc462d5a3a.png">
<img width="1424" alt="Screen Shot 2021-02-16 at 10 30 44" src="https://user-images.githubusercontent.com/1158253/108069405-1789ee80-7042-11eb-8425-44ad427b7565.png">
