### PR TITLE
Remove outdated SvelteKit configuration

### DIFF
--- a/guide/svelte.md
+++ b/guide/svelte.md
@@ -81,9 +81,6 @@ module.exports = {
     target: '#svelte',
 
     vite: {
-      ssr: {
-        noExternal: Object.keys(pkg.dependencies || {})
-      },
       plugins: [
         require('vite-plugin-windicss').default()
       ]


### PR DESCRIPTION
The SSR `noExternal` directive has been removed from the SvelteKit templates and is no longer recommended.