### PR TITLE
Small typo in `safelist` example

### DIFF
--- a/guide/extractions.md
+++ b/guide/extractions.md
@@ -45,7 +45,7 @@ function range(size, startAt = 1) {
 
 export default defineConfig({
   safelist: [
-    range(30).map(i => `p-${i}`), // p-1 to p-3
+    range(3).map(i => `p-${i}`), // p-1 to p-3
     range(10).map(i => `mt-${i}`), // mt-1 to mt-10
   ],
 })


### PR DESCRIPTION
I think the example is a pseudo code (since there is no range function?!) but it looks wrong compared to the next line https://github.com/windicss/docs/edit/main/guide/extractions.md#L49