### PR TITLE
fix: typo in module name

### DIFF
--- a/integrations/vite.md
+++ b/integrations/vite.md
@@ -65,7 +65,7 @@ Rename it to `tailwind.config.ts` and things just work!
 
 ```ts
 // tailwind.config.ts
-import { defineConfig } from 'windcss/helpers'
+import { defineConfig } from 'windicss/helpers'
 import formsPlugin from 'windicss/plugin/forms'
 
 export default defineConfig({


### PR DESCRIPTION
As someone recently did the same thing at one of my projects, I feel no shame anymore to create stupidly simple PRs 😉
