### PR TITLE
Small grammar fix for heading

### DIFF
--- a/posts/v30.md
+++ b/posts/v30.md
@@ -34,7 +34,7 @@ Then, the following is the Attributify mode by windi:
 
 The beta version of [vite-plugin](https://github.com/windicss/vite-plugin-windicss/tree/next#install) already has the support for Attributify. You can follow the instructions to install and try it out today! Integrations for other frameworks/tools will follow up soon. 
 
-### Why Using It
+### Why use it?
 
 #### Simplicity
 


### PR DESCRIPTION
**Why use it** is more grammatically correct than **Why Using it**  😃 