### PR TITLE
chore: typo

### DIFF
--- a/features/value-auto-infer.md
+++ b/features/value-auto-infer.md
@@ -51,7 +51,7 @@ w-{fraction} -> width: {fraction -> precent};
 ```css
 text-{color} -> color: rgba(...);
 
-border-hex-{hex} -> background-color: rgba(...);
+border-hex-{hex} -> border-color: rgba(...);
 ```
 
 <InlinePlayground 


### PR DESCRIPTION
"border" was mispelled as "background"