### PR TITLE
Add Javascript API integrations page

### DIFF
--- a/.vitepress/config/sidebar.ts
+++ b/.vitepress/config/sidebar.ts
@@ -148,7 +148,7 @@ export const sidebar: DefaultTheme.Config['sidebar'] = {
         // { text: 'Next.js', link: '/integrations/nextjs' },
         { text: 'Svelte', link: '/integrations/svelte' },
         { text: 'CLI', link: '/integrations/cli' },
-        { text: 'Javascript', link: '/integrations/javascript' },
+        { text: 'JavaScript API', link: '/integrations/javascript' },
         { text: 'PostCSS', link: '/integrations/postcss' },
         { text: 'VS Code', link: '/editors/vscode' },
         { text: 'WebStorm', link: '/editors/webstorm' },

--- a/.vitepress/config/sidebar.ts
+++ b/.vitepress/config/sidebar.ts
@@ -148,6 +148,7 @@ export const sidebar: DefaultTheme.Config['sidebar'] = {
         // { text: 'Next.js', link: '/integrations/nextjs' },
         { text: 'Svelte', link: '/integrations/svelte' },
         { text: 'CLI', link: '/integrations/cli' },
+        { text: 'Javascript', link: '/integrations/javascript' },
         { text: 'PostCSS', link: '/integrations/postcss' },
         { text: 'VS Code', link: '/editors/vscode' },
         { text: 'WebStorm', link: '/editors/webstorm' },

--- a/.vitepress/theme/components/logos/Logo.vue
+++ b/.vitepress/theme/components/logos/Logo.vue
@@ -9,7 +9,7 @@ import VSCode from '/@vite-icons/logos/visual-studio-code'
 import Webstrom from '/@vite-icons/logos/webstorm'
 import PostCSS from '/@vite-icons/logos/postcss'
 import Gridsome from '/@vite-icons/logos/gridsome-icon'
-import Javascript from '/@vite-icons/logos/javascript'
+import JavaScript from '/@vite-icons/logos/javascript'
 import NextJs from './NuxtJs.vue'
 import Vite from './ViteLogo.vue'
 import Windi from './WindiLogo.vue'
@@ -47,7 +47,7 @@ const Logo = computed(() => {
     case 'postcss':
       return PostCSS
     case 'javascript':
-      return Javascript
+      return JavaScript
     default:
       return Windi
   }

--- a/.vitepress/theme/components/logos/Logo.vue
+++ b/.vitepress/theme/components/logos/Logo.vue
@@ -9,6 +9,7 @@ import VSCode from '/@vite-icons/logos/visual-studio-code'
 import Webstrom from '/@vite-icons/logos/webstorm'
 import PostCSS from '/@vite-icons/logos/postcss'
 import Gridsome from '/@vite-icons/logos/gridsome-icon'
+import Javascript from '/@vite-icons/logos/javascript'
 import NextJs from './NuxtJs.vue'
 import Vite from './ViteLogo.vue'
 import Windi from './WindiLogo.vue'
@@ -45,6 +46,8 @@ const Logo = computed(() => {
       return Webstrom
     case 'postcss':
       return PostCSS
+    case 'javascript':
+      return Javascript
     default:
       return Windi
   }

--- a/guide/installation.md
+++ b/guide/installation.md
@@ -32,11 +32,6 @@ Supports for build tools are framework-agnostic, they work for most frameworks w
     link: '/integrations/cli',
     logo: 'cli',
   },
-    {
-    title: 'Javascript',
-    link: '/integrations/javascript',
-    logo: 'javascript',
-  },
 ]"/>
 
 ## Frameworks
@@ -86,6 +81,16 @@ In addition to general build tools support, we also provide integrations for the
     link: '/editors/webstorm',
     logo: 'webstorm',
     wip: true
+  },
+]"/>
+
+## API
+
+<Integrations class="mb-5" :items="[
+  {
+    title: 'JavaScript',
+    link: '/integrations/javascript',
+    logo: 'javascript',
   },
 ]"/>
 

--- a/guide/installation.md
+++ b/guide/installation.md
@@ -32,6 +32,11 @@ Supports for build tools are framework-agnostic, they work for most frameworks w
     link: '/integrations/cli',
     logo: 'cli',
   },
+    {
+    title: 'Javascript',
+    link: '/integrations/javascript',
+    logo: 'javascript',
+  },
 ]"/>
 
 ## Frameworks

--- a/integrations/javascript.md
+++ b/integrations/javascript.md
@@ -1,6 +1,6 @@
 <Logo name="javascript" class="logo-float-xl"/>
 
-# Windi CSS Javascript API
+# Windi CSS JavaScript API
 
 <PackageInfo name="windicss" author="voorjaar" />
 
@@ -21,31 +21,31 @@ npm i -D windicss
 ### Setup with interpret mode
 
 ```js
-const { Processor } = require("windicss/lib");
-const { HTMLParser } = require("windicss/utils/parser");
+const { Processor } = require('windicss/lib')
+const { HTMLParser } = require('windicss/utils/parser')
 
 export function generateStyles(html) {
   // Get windi processor
-  const processor = new Processor();
+  const processor = new Processor()
 
   // Parse all classes and put into one line to simplify operations
   const htmlClasses = new HTMLParser(html)
     .parseClasses()
-    .map((i) => i.result)
-    .join("");
+    .map(i => i.result)
+    .join('')
 
   // Generate preflight based on the html we input
-  const preflightSheet = processor.preflight(html);
+  const preflightSheet = processor.preflight(html)
 
   // Process the html classes to an interpreted style sheet
-  const interpretedSheet = processor.interpret(htmlClasses).styleSheet;
+  const interpretedSheet = processor.interpret(htmlClasses).styleSheet
 
   // Build styles
-  const APPEND = false;
-  const MINIFY = false;
-  const styles = interpretedSheet.extend(preflightSheet, APPEND).build(MINIFY);
+  const APPEND = false
+  const MINIFY = false
+  const styles = interpretedSheet.extend(preflightSheet, APPEND).build(MINIFY)
 
-  return styles;
+  return styles
 }
 ```
 
@@ -56,55 +56,55 @@ Compile mode requires a bit more leg work to swap out the compiled classnames fo
 Read more about compile mode [here](/posts/modes.html).
 
 ```js
-const { Processor } = require("windicss/lib");
-const { HTMLParser } = require("windicss/utils/parser");
+const { Processor } = require('windicss/lib')
+const { HTMLParser } = require('windicss/utils/parser')
 
 export function generateStyles(html) {
   // Get windi processor
-  const processor = new Processor();
+  const processor = new Processor()
 
   // Parse html to get array of class matches with location
-  const parser = new HTMLParser(html);
+  const parser = new HTMLParser(html)
 
   // Generate preflight based on the html we input
-  const preflightSheet = processor.preflight(html);
+  const preflightSheet = processor.preflight(html)
 
-  const PREFIX = "windi-";
-  const outputCSS = [];
-  let outputHTML = "";
-  let indexStart = 0;
+  const PREFIX = 'windi-'
+  const outputCSS = []
+  let outputHTML = ''
+  let indexStart = 0
 
   parser.parseClasses().forEach((p) => {
     // add HTML substring from index to match start
-    outputHTML += html.substring(indexStart, p.start);
+    outputHTML += html.substring(indexStart, p.start)
 
     // generate stylesheet
-    const style = processor.compile(p.result, PREFIX);
+    const style = processor.compile(p.result, PREFIX)
 
     // add the styleSheet to the styles stack
-    outputCSS.push(style.styleSheet);
+    outputCSS.push(style.styleSheet)
 
     // append ignored classes and push to output
-    outputHTML += [style.className, ...style.ignored].join(" ");
+    outputHTML += [style.className, ...style.ignored].join(' ')
 
     // mark the end as our new start for next itteration
-    indexStart = p.end;
-  });
+    indexStart = p.end
+  })
 
   // append the remainder of html
-  outputHTML += html.substring(indexStart);
+  outputHTML += html.substring(indexStart)
 
   // Build styles
-  const MINIFY = false;
+  const MINIFY = false
   const styles = outputCSS
     // extend the preflight sheet with each sheet from the stack
     .reduce((acc, curr) => acc.extend(curr), preflightSheet)
-    .build(MINIFY);
+    .build(MINIFY)
 
   return {
     styles,
-    outputHTML
-  };
+    outputHTML,
+  }
 }
 ```
 
@@ -116,54 +116,55 @@ Read more about attributify mode [here](/posts/v30.html#attributify-mode)
 And you can find the syntax [here](/posts/attributify.html)
 
 ```js
-const { Processor } = require("windicss/lib");
-const { HTMLParser } = require("windicss/utils/parser");
+const { Processor } = require('windicss/lib')
+const { HTMLParser } = require('windicss/utils/parser')
 
 export function generateStyles(html) {
   // Get windi processor
-  const processor = new Processor();
+  const processor = new Processor()
 
   // Parse html to get array of class matches with location
-  const parser = new HTMLParser(html);
+  const parser = new HTMLParser(html)
 
   // Generate preflight based on the html we input
-  const preflightSheet = processor.preflight(html);
+  const preflightSheet = processor.preflight(html)
 
   // Always returns array
-  const castArray = (val) => (Array.isArray(val) ? val : [val]);
+  const castArray = val => (Array.isArray(val) ? val : [val])
 
   const attrs = parser.parseAttrs().reduceRight((acc, curr) => {
     // get current match key
-    const attrKey = curr.key;
+    const attrKey = curr.key
 
     // ignore class or className attributes
-    if (attrKey === "class" || attrKey === "className") return acc;
+    if (attrKey === 'class' || attrKey === 'className') return acc
 
     // get current match value as array
-    const attrValue = castArray(curr.value);
+    const attrValue = castArray(curr.value)
 
     // if current match key is already in accumulator
     if (attrKey in acc) {
       // get current attr key value as array
-      const attrKeyValue = castArray(acc[attrKey]);
+      const attrKeyValue = castArray(acc[attrKey])
 
       // append current value to accumulator value
-      acc[attrKey] = [...attrKeyValue, ...attrValue];
-    } else {
+      acc[attrKey] = [...attrKeyValue, ...attrValue]
+    }
+    else {
       // else add atrribute value array to accumulator
-      acc[attrKey] = attrValue;
+      acc[attrKey] = attrValue
     }
 
-    return acc;
-  }, {});
+    return acc
+  }, {})
 
   // Build styles
-  const MINIFY = false;
+  const MINIFY = false
   const styles = processor
     .attributify(attrs)
     .styleSheet.extend(preflightSheet)
-    .build(MINIFY);
+    .build(MINIFY)
 
-  return styles;
+  return styles
 }
 ```

--- a/integrations/javascript.md
+++ b/integrations/javascript.md
@@ -1,0 +1,171 @@
+<Logo name="javascript" class="logo-float-xl"/>
+
+# Windi CSS Javascript API
+
+<PackageInfo name="windicss" author="voorjaar" />
+
+## About
+
+If using the CLI does not fit your workflow, you could directly use the Windi CSS API.
+
+## Install
+
+Add the package:
+
+```bash
+npm i -D windicss
+```
+
+## Usage
+
+### Setup with interpret mode
+
+```js
+const { Processor } = require("windicss/lib");
+const { HTMLParser } = require("windicss/utils/parser");
+
+export function generateStyles(html) {
+  // Get windi processor
+  const processor = new Processor();
+
+  // Parse all classes and put into one line to simplify operations
+  const htmlClasses = new HTMLParser(html)
+    .parseClasses()
+    .map((i) => i.result)
+    .join("");
+
+  // Generate preflight based on the html we input
+  const preflightSheet = processor.preflight(html);
+
+  // Process the html classes to an interpreted style sheet
+  const interpretedSheet = processor.interpret(htmlClasses).styleSheet;
+
+  // Build styles
+  const APPEND = false;
+  const MINIFY = false;
+  const styles = interpretedSheet.extend(preflightSheet, APPEND).build(MINIFY);
+
+  return styles;
+}
+```
+
+### Setup with compile mode
+
+Compile mode requires a bit more leg work to swap out the compiled classnames for the current ones.
+
+Read more about compile mode [here](/posts/modes.html).
+
+```js
+const { Processor } = require("windicss/lib");
+const { HTMLParser } = require("windicss/utils/parser");
+
+export function generateStyles(html) {
+  // Get windi processor
+  const processor = new Processor();
+
+  // Parse html to get array of class matches with location
+  const parser = new HTMLParser(html);
+
+  // Generate preflight based on the html we input
+  const preflightSheet = processor.preflight(html);
+
+  console.log(preflightSheet);
+
+  const PREFIX = "windi-";
+  const outputCSS = [];
+  let outputHTML = "";
+  let indexStart = 0;
+
+  parser.parseClasses().forEach((p) => {
+    // add HTML substring from index to match start
+    outputHTML += html.substring(indexStart, p.start);
+
+    // generate stylesheet
+    const style = processor.compile(p.result, PREFIX);
+
+    // add the styleSheet to the styles stack
+    outputCSS.push(style.styleSheet);
+
+    // append ignored classes and push to output
+    outputHTML += [style.className, ...style.ignored].join(" ");
+
+    // mark the end as our new start for next itteration
+    indexStart = p.end;
+  });
+
+  // append the remainder of html
+  outputHTML += html.substring(indexStart);
+
+  // Build styles
+  const MINIFY = false;
+  const styles = outputCSS
+    // extend the preflight sheet with each sheet from the stack
+    .reduce((acc, curr) => acc.extend(curr), preflightSheet)
+    .build(MINIFY);
+
+  return {
+    styles,
+    outputHTML
+  };
+}
+```
+
+### Setup with attributify mode
+
+Attributify mode requires a bit more leg work to parse each individual attribute.
+
+Read more about attributify mode [here](/posts/v30.html#attributify-mode)
+And you can find the syntax [here](/posts/attributify.html)
+
+```js
+const { Processor } = require("windicss/lib");
+const { HTMLParser } = require("windicss/utils/parser");
+
+export function generateStyles(html) {
+  // Get windi processor
+  const processor = new Processor();
+
+  // Parse html to get array of class matches with location
+  const parser = new HTMLParser(html);
+
+  // Generate preflight based on the html we input
+  const preflightSheet = processor.preflight(html);
+
+  // Always returns array
+  const castArray = (val) => (Array.isArray(val) ? val : [val]);
+
+  const attrs = parser.parseAttrs().reduceRight((acc, curr) => {
+    // get current match key
+    const attrKey = curr.key;
+
+    // ignore class or className attributes
+    if (attrKey === "class" || attrKey === "className") return acc;
+
+    // get current match value as array
+    const attrValue = castArray(curr.value);
+
+    // if current match key is already in accumulator
+    if (attrKey in acc) {
+      // get current attr key value as array
+      const attrKeyValue = castArray(acc[attrKey]);
+
+      // append current value to accumulator value
+      acc[attrKey] = [...attrKeyValue, ...attrValue];
+    } else {
+      // else add atrribute value array to accumulator
+      acc[attrKey] = attrValue;
+    }
+
+    return acc;
+  }, {});
+
+  // Build styles
+  const MINIFY = false;
+  const styles = processor
+    .attributify(attrs)
+    .styleSheet.extend(preflightSheet)
+    .build(MINIFY);
+
+  return styles;
+}
+```

--- a/integrations/javascript.md
+++ b/integrations/javascript.md
@@ -69,8 +69,6 @@ export function generateStyles(html) {
   // Generate preflight based on the html we input
   const preflightSheet = processor.preflight(html);
 
-  console.log(preflightSheet);
-
   const PREFIX = "windi-";
   const outputCSS = [];
   let outputHTML = "";


### PR DESCRIPTION
I've previously opened up [this](https://github.com/windicss/windicss/issues/293) issue about how to consume the Javascript API of Windi CSS, and was given some good example files.

But I'd like it if they were added to the docs so that other developers won't have to open the same issues again.

Let me know if you would like to change some wording, or I have a misspelling, or anything I need to change.