### PR TITLE
docs: make context consistent

### DIFF
--- a/plugins/community/question-mark.md
+++ b/plugins/community/question-mark.md
@@ -14,7 +14,7 @@ Install the plugin from npm:
 npm install --save-dev @windicss/plugin-question-mark
 ```
 
-Then add the plugin to your `tailwind.config.js` file:
+Then add the plugin to your `windi.config.js` file:
 
 ```js
 // windi.config.js


### PR DESCRIPTION
In line 17 it's
>Then add the plugin to your `tailwind.config.js` file:

while in line 20 it's 
> // windi.config.js