### PR TITLE
docs: update features/RTL document

### DIFF
--- a/.vitepress/config/sidebar.ts
+++ b/.vitepress/config/sidebar.ts
@@ -132,6 +132,7 @@ export const sidebar: DefaultTheme.Config['sidebar'] = {
         { text: 'Shortcuts', link: '/features/shortcuts' },
         { text: 'Responsive Design', link: '/features/responsive-design' },
         { text: 'Dark Mode', link: '/features/dark-mode' },
+        { text: 'RTL', link: '/features/rtl' },
         { text: 'Important Prefix', link: '/features/important-prefix' },
         { text: 'Directives', link: '/features/directives' },
         { text: 'Visual Analyzer', link: '/features/analyzer' },

--- a/features/index.md
+++ b/features/index.md
@@ -81,7 +81,6 @@ export default {
 
 <LearnMore to="/features/shortcuts" />
 
-
 ### Dark Mode
 
 ```html
@@ -89,6 +88,14 @@ export default {
 ```
 
 <LearnMore to="/features/dark-mode" />
+
+### RTL
+
+```html
+<div class="text-green-400 rtl:(text-red-400 text-right)"></div>
+```
+
+<LearnMore to="/features/rtl" />
 
 ### Directives
 

--- a/features/rtl.md
+++ b/features/rtl.md
@@ -2,9 +2,11 @@
 
 Windi CSS has out-of-box RTL support with zero configuration from `v2.5.4`.
 
-By prefixing the `rtl:` variant to the utilities, they will only apply when RTL is enabled. With the following example, the `Preview` text will be `text-right` and `text-red-400` on the RTL. Try play with it:
+By prefixing the `rtl:` variant to the utilities, they will only apply when RTL is enabled.
 
-<InlinePlayground :input="'text-green-400 rtl:(text-right text-red-400)'" :showCSS="true" :showPreview="true" />
+<!-- With the following example, the `Preview` text will be `text-right` and `text-red-400` on the RTL. Try play with it: -->
+
+<!-- <InlinePlayground :input="'text-green-400 rtl:(text-right text-red-400)'" :showCSS="true" :showPreview="true" /> -->
 
 It's easy to enable RTL, you just need to apply `dir="rtl"` on the `html` element to make it affects.
 

--- a/features/rtl.md
+++ b/features/rtl.md
@@ -1,0 +1,23 @@
+# RTL
+
+Windi CSS has out-of-box RTL support with zero configuration from `v2.5.4`.
+
+By prefixing the `rtl:` variant to the utilities, they will only apply when RTL is enabled. With the following example, the `Preview` text will be `text-right` and `text-red-400` on the RTL. Try play with it:
+
+<InlinePlayground :input="'text-green-400 rtl:(text-right text-red-400)'" :showCSS="true" :showPreview="true" />
+
+It's easy to enable RTL, you just need to apply `dir="rtl"` on the `html` element to make it affects.
+
+```html
+<html>
+<body>
+  <!-- RTL disabled -->
+</body>
+</html>
+
+<html dir="rtl">
+<body>
+  <!-- RTL enabled -->
+</body>
+</html>
+```


### PR DESCRIPTION
- update document for RTL

I commented the RTL example code because I didn’t find the `@windicss/vitepress-theme` package in windicss repo. By providing component to switch `RTL`, it seems to be very useful like the example code for dark mode.