### PR TITLE
Fix a typo

### DIFF
--- a/guide/extractions.md
+++ b/guide/extractions.md
@@ -32,7 +32,7 @@ export default defineConfig({
 })
 ```
 
-Or to be more fixable:
+Or to be more flexible:
 
 ```ts windi.config.js
 import { defineConfig } from 'windicss/helpers'


### PR DESCRIPTION
After reading this a few times, I think "fixable" was intended to be "flexible".