### PR TITLE
chore: fix typo 

### DIFF
--- a/integrations/vite.md
+++ b/integrations/vite.md
@@ -126,7 +126,7 @@ By default, we scan your source code statically and find all the usages of the u
 <div className={`p-${size}`}>
 ```
 
-For that, you will need to specify the possible combinations in the `safelist` options of `vite.config.js`.
+For that, you will need to specify the possible combinations in the `safelist` options of `windi.config.ts`.
 
 ```ts windi.config.ts
 import { defineConfig } from 'vite-plugin-windicss'


### PR DESCRIPTION
Fix typo in `vite.md`
I believe the file being referred to for safelist is `windi.config.ts` and not `vite.config.js`