### PR TITLE
Extend typography readme with "prose" class usage

### DIFF
--- a/plugins/official/typography.md
+++ b/plugins/official/typography.md
@@ -34,6 +34,15 @@ export default {
 }
 ```
 
+No you can use the `prose` utility class (or one of the variants) on the wrapping element to style the HTML elements contained:
+
+```html
+<article class="prose">
+  <h1>Styled heading!</h1>
+  <blockquote>Very useful for styling markdown content!</blockquote>
+</article>
+```
+
 ## Disabling size modifiers
 
 ```js windi.config.js

--- a/plugins/official/typography.md
+++ b/plugins/official/typography.md
@@ -34,7 +34,7 @@ export default {
 }
 ```
 
-No you can use the `prose` utility class (or one of the variants) on the wrapping element to style the HTML elements contained:
+Now you can use the `prose` utility class (or one of the variants) on the wrapping element to style the HTML elements contained:
 
 ```html
 <article class="prose">


### PR DESCRIPTION
As a new Windi user I stumbled on this issue where I needed to add the `prose` class to a wrapping element. For this I had to read the Tailwind docs to find out. To avoid wasted time for other new users I've added it to this page.