### PR TITLE
docs: modify plugin instructions for vite sveltekit

### DIFF
--- a/integrations/vite.md
+++ b/integrations/vite.md
@@ -304,7 +304,7 @@ const config = {
     target: '#svelte',
     vite: () => ({
       plugins: [
-        WindiCSS.default(),
+        WindiCSS(),
       ],
     }),
   },


### PR DESCRIPTION
As of an update, WindiCSS.default() is no longer valid. Trying to build with it will result in a "Error WindiCSS.default is not a function" error. Change it back to WindiCSS() to fix build.