### PR TITLE
docs: update vite sveltekit instructions

### DIFF
--- a/integrations/vite.md
+++ b/integrations/vite.md
@@ -289,24 +289,23 @@ See [examples](https://github.com/windicss/vite-plugin-windicss/blob/main/exampl
 
 ---
 
-## SvelteKit (as of 1.0.0-next.100)
+## SvelteKit (as of 1.0.0-next.102)
 
 Install plugin with `npm i -D vite-plugin-windicss` and adapt the svelte config:
 
 ```js svelte.config.js
-import preprocess from 'svelte-preprocess'
 import WindiCSS from 'vite-plugin-windicss'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-  preprocess: preprocess(),
   kit: {
+    // hydrate the <div id="svelte"> element in src/app.html
     target: '#svelte',
-    vite: () => ({
+    vite: {
       plugins: [
-        WindiCSS.default(),
+        WindiCSS(),
       ],
-    }),
+    },
   },
 }
 export default config
@@ -323,5 +322,5 @@ Add `import "virtual:windi.css"` to the top of your __layout.svelte file:
   if (browser) import("virtual:windi-devtools")
   // ...
 </script>
-<!-- ...rest of $layout.svelte -->
+<!-- ...rest of __layout.svelte -->
 ```


### PR DESCRIPTION
* Change plugin WindiCSS.default() to WindiCSS() to bring it in line with change https://github.com/windicss/vite-plugin-windicss/commit/713743fec2a2961351797fec8e549f13083fee94 
* Remove svelte-preprocess as it is not present by default and could potentially mislead users into thinking it is necessary
* Rename renaming $layout.svelte to newer __layout.svelte, changed as of 1.0.0-next.102
* The svelte config now actually looks like the svelte config that is default