### PR TITLE
docs: update vite sveltekit integration instructions

### DIFF
--- a/integrations/vite.md
+++ b/integrations/vite.md
@@ -289,26 +289,31 @@ See [examples](https://github.com/windicss/vite-plugin-windicss/blob/main/exampl
 
 ---
 
-## SvelteKit (as of 1.0.0-next.100)
+## SvelteKit (as of 1.0.0-next.102)
 
 Install plugin with `npm i -D vite-plugin-windicss` and adapt the svelte config:
 
-```js svelte.config.js
+```diff
 import preprocess from 'svelte-preprocess'
-import WindiCSS from 'vite-plugin-windicss'
++ import WindiCSS from 'vite-plugin-windicss'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
+  // Consult https://github.com/sveltejs/svelte-preprocess
+  // for more information about preprocessors
   preprocess: preprocess(),
+
   kit: {
+    // hydrate the <div id="svelte"> element in src/app.html
     target: '#svelte',
-    vite: () => ({
-      plugins: [
-        WindiCSS.default(),
-      ],
-    }),
++   vite: {
++     plugins: [
++       WindiCSS(),
++     ],
++   },
   },
-}
+};
+
 export default config
 ```
 
@@ -323,5 +328,5 @@ Add `import "virtual:windi.css"` to the top of your __layout.svelte file:
   if (browser) import("virtual:windi-devtools")
   // ...
 </script>
-<!-- ...rest of $layout.svelte -->
+<!-- ...rest of __layout.svelte -->
 ```


### PR DESCRIPTION
* Change WindiCSS.default() to WindiCSS() in line with https://github.com/windicss/vite-plugin-windicss/commit/713743f
* Use diff codebock instead of js to better show what needs to be added
* Version should be next-102, which is when $layout was renamed to __layout, not next-100
* Added comments as they actually appear on the config
* Changed the last $layout to __layout