### PR TITLE
docs: support TypeScript in Next.js example

### DIFF
--- a/integrations/webpack.md
+++ b/integrations/webpack.md
@@ -212,7 +212,7 @@ import { defineConfig } from 'windicss/helpers'
 
 export default defineConfig({
   extract: {
-    include: ['**/*.{jsx,css}'],
+    include: ['**/*.{jsx,tsx,css}'],
     exclude: ['node_modules', '.git', '.next'],
   },
 })


### PR DESCRIPTION
Adding `tsx` to the `include` list makes the example work in Next.js codebases that uses TypeScript, and should be harmless in ones that don't.