### PR TITLE
Change NPM Repo to new module

### DIFF
--- a/integrations/nuxt.md
+++ b/integrations/nuxt.md
@@ -2,7 +2,7 @@
 
 # Integration for [Nuxt.js](https://nuxtjs.org)
 
-<PackageInfo name="nuxt-windicss-module" author="harlan-zw" />
+<PackageInfo name="nuxt-windicss" author="harlan-zw" />
 
 ## Install
 
@@ -21,6 +21,18 @@ export default {
     'nuxt-windicss',
   ],
 }
+```
+
+### Nuxt 3
+
+```js nuxt.config.js
+import { defineNuxtConfig } from 'nuxt3'
+
+export default defineNuxtConfig({
+  buildModules: [
+    'nuxt-windicss',
+  ],
+})
 ```
 
 ## Migrating from tailwind


### PR DESCRIPTION
The Docs had the old nuxt-windicss-module which is now migrated to nuxt-windicss and adds support for Nuxt 3.

!!! The GitHub repo and NPM package have different names. Don't merge for now. https://github.com/windicss/nuxt-windicss-module/issues/125