### PR TITLE
docs: correct typo Table of Content to Table of Contents

### DIFF
--- a/.vitepress/theme/components/molecules/TableOfContents.vue
+++ b/.vitepress/theme/components/molecules/TableOfContents.vue
@@ -49,7 +49,7 @@ const hasHeaders = computed(() => headers.value && headers.value?.length > 0)
     <li>
       <SidebarLinkItem
         :item="{
-          text: 'Table of Content',
+          text: 'Table of Contents',
         }"
         class="px-2"
         :header="true"

--- a/.vitepress/theme/components/templates/TheRightSidebar.vue
+++ b/.vitepress/theme/components/templates/TheRightSidebar.vue
@@ -1,7 +1,7 @@
 <template>
   <aside class="hidden lg:block">
     <div class="sticky top-$header-height h-$full-header overflow-y-auto">
-      <TableOfContent />
+      <TableOfContents />
     </div>
   </aside>
 </template>

--- a/components.d.ts
+++ b/components.d.ts
@@ -75,7 +75,7 @@ declare module 'vue' {
     SidebarNav: typeof import('./.vitepress/theme/components/molecules/sidebar/SidebarNav.vue')['default']
     SingleColor: typeof import('./.vitepress/theme/components/molecules/SingleColor.vue')['default']
     Sponsors: typeof import('./.vitepress/theme/components/global/Sponsors.vue')['default']
-    TableOfContent: typeof import('./.vitepress/theme/components/molecules/TableOfContent.vue')['default']
+    TableOfContents: typeof import('./.vitepress/theme/components/molecules/TableOfContents.vue')['default']
     TheHeader: typeof import('./.vitepress/theme/components/templates/TheHeader.vue')['default']
     TheHome: typeof import('./.vitepress/theme/components/templates/TheHome.vue')['default']
     TheLayout: typeof import('./.vitepress/theme/components/templates/TheLayout.vue')['default']


### PR DESCRIPTION
Table of contents is spelt incorrectly and it was bothering me a little.
Rename the SidebarLinkItem heading and also the TableOfContent component.

Please check if it broke anything