### PR TITLE
fix: dropdown menu content overflow

### DIFF
--- a/.vitepress/theme/components/molecules/DropdownLink.vue
+++ b/.vitepress/theme/components/molecules/DropdownLink.vue
@@ -36,6 +36,7 @@ function toggle() {
       v-if="open"
       class="
         absolute top-10 right-0 z-50
+        max-h-[60vh] overflow-y-auto
         p-2 min-w-40
         rounded-md border
         bg-$windi-bg


### PR DESCRIPTION
Closes #142.

Limits the max height of dropdown menus and adds a scrollbar if content overflows:

https://user-images.githubusercontent.com/43280336/140237971-f750f5c8-21c7-4870-93b3-47bf133ea80b.mov


