### PR TITLE
docs: corrected spelling & rewrote parts for better grammar 

### DIFF
--- a/features/analyzer.md
+++ b/features/analyzer.md
@@ -2,13 +2,13 @@
 
 <PackageInfo name="windicss-analysis" author="antfu" />
 
-An visual analyser tool for [Windi CSS](https://github.com/windicss/windicss). Browse your utilities usages, have an overview of your design system, identify "bad practices", and more!
+A visual analyser tool for [Windi CSS](https://github.com/windicss/windicss). Browse your utility usages, get an overview of your design system, identify "bad practices", and more!
 
 <img src="https://user-images.githubusercontent.com/11247099/113150805-0c43f880-9267-11eb-85a6-ec1a2f1eed37.png" />
 
 ## Get Started
 
-Run the following command under your project root
+Run the following command in your project root
 
 ```bash
 npx windicss-analysis
@@ -18,7 +18,7 @@ The analysis report will be available at http://localhost:8113/
 
 ### NPM
 
-Or you can install locally to reuse the same version of your local `windicss` module
+Or you can install it locally to use the same version as your local `windicss` module
 
 ```bash
 npm i -D windicss-analysis
@@ -43,11 +43,10 @@ From v0.8.0 of [Windi CSS Intellisense](https://github.com/windicss/windicss-int
 
 ### Online Preview
 
-You can have a preview the analysing report of the analyser itself
-
+You can preview the report of the analyser itself at 
 [analysis-demo.windicss.org](http://analysis-demo.windicss.org)
 
-You can genreate your own report and host it statically by running the following command
+You can generate your own report and host it statically by running the following command:
 
 ```bash
 npx windicss-analysis --html dist
@@ -57,7 +56,7 @@ npx windicss-analysis --html dist
 
 ### It does not detect my files
 
-You will need to configure the `extract.include` options in `windi.config.js` instead of your framework's configurations file so it can be understood by the analyzer so as other integrations support. For example:
+You will need to explicitly configure the `extract.include` option in `windi.config.js` instead of your framework's configuration file so it can be understood by the analyzer. For example:
 
 ```ts windi.config.js
 import { defineConfig } from 'windicss/helpers'
@@ -74,7 +73,7 @@ export default defineConfig({
 
 ### Can I use the report for other tools?
 
-Yes. You can get the raw json file via the CLI
+Yes. You can get the raw JSON file via the CLI
 
 ```bash
 npx windicss-analysis --json report.json
@@ -91,9 +90,9 @@ import type { AnalysisReport } from 'windicss-analysis'
 const report = rawReport as AnalysisReport
 ```
 
-### Programmatic Use?
+### Can I use Windi CSS programmatically?
 
-Yes. Just like a normal Node package:
+Yes, just like a normal Node package:
 
 ```ts
 import { startServer } from 'windicss-analysis'
@@ -101,4 +100,4 @@ import { startServer } from 'windicss-analysis'
 startServer({ /* ... */ })
 ```
 
-Check out the type decrations for more APIs avaliable.
+Check out the type declarations to see avaliable APIs.

--- a/features/analyzer.md
+++ b/features/analyzer.md
@@ -100,4 +100,4 @@ import { startServer } from 'windicss-analysis'
 startServer({ /* ... */ })
 ```
 
-Check out the type declarations to see avaliable APIs.
+Check out the type declarations to see available APIs.

--- a/features/attributify.md
+++ b/features/attributify.md
@@ -51,7 +51,7 @@ md-bg = "blue-300 dark:blue-400"
 
 ## Prefix
 
-If you are concerned about naming confliction, you can add custom prefix to attributify mode by:
+If you are concerned about naming conflicts, you can add a custom prefix to the `attributify` mode by:
 
 ```js windi.config.js
 export default {
@@ -95,7 +95,7 @@ You actually have two **programming paradigms** to choose from:
    dark=...
    ```
 
-> And of course, you can also **mix them**, but I personally **don't recommend**. Just choosing one and stick to it. You will find your code becomes clearer.
+> And of course, you can also **mix them**, but I personally **don't recommend**. Just choose one and stick to it. You will find your code becomes clearer.
 
 ## Utilities
 

--- a/features/dark-mode.md
+++ b/features/dark-mode.md
@@ -2,7 +2,7 @@
 
 Windi CSS has out-of-box Dark Mode support.
 
-By prefixing the `dark:` variant to the utilities, they will only apply when dark mode is enabled. With the following example, the `Preview` text will be red on the light mode, and green on the dark mode. Try play with it: 
+By prefixing the `dark:` variant to utilities, they will only apply when dark mode is enabled. With the following example, the `Preview` text will be red on the light mode, and green on the dark mode. Try to play with it: 
 
 <ToggleDark />
 
@@ -12,7 +12,7 @@ We have two modes for enabling dark mode, [class mode](#class-mode) and [media q
 
 ## Class mode
 
-Class mode gives you better controls over when should the dark mode enables.
+Class mode gives you better control over when dark mode should enable.
 
 ```js windi.config.js
 export default {
@@ -21,7 +21,7 @@ export default {
 }
 ```
 
-It detects parent element's `class="dark"`, and normally you can apply it on the `html` element to make it affects globally.
+It detects the parent element's `class="dark"`, and usually you can apply it on the `html` element to make it work globally.
 
 ```html
 <html>
@@ -37,7 +37,7 @@ It detects parent element's `class="dark"`, and normally you can apply it on the
 </html>
 ```
 
-You can use the following snippet to make the color scheme matches with users' system preference, or write your own logic to manage it.
+You can use the following snippet to make the color scheme match with the user's system preference, or write your own logic to manage it.
 
 ```js
 if (window.matchMedia('(prefers-color-scheme: dark)').matches)
@@ -59,7 +59,7 @@ else
 
 ## Media query mode 
 
-In media query mode, it uses the built-in `@media (prefers-color-scheme: dark)` query from the browser that always matches with the users' system preference. 
+In media query mode, it uses the built-in `@media (prefers-color-scheme: dark)` query from the browser that always matches with the user's system preference. 
 
 ```js windi.config.js
 export default {

--- a/features/directives.md
+++ b/features/directives.md
@@ -66,7 +66,7 @@ The `@screen` directive allows you to create media queries that reference your b
 
 ## @layer
 
-The `@layer` directive makes sure the order of each class. Valid layers are `base`, `components`, and `utilities`.
+The `@layer` directive sets the order of how each class is applied. Valid layers are `base`, `components`, and `utilities`.
 
 <DirectivesPlayground 
 :input='`

--- a/features/important-prefix.md
+++ b/features/important-prefix.md
@@ -1,6 +1,6 @@
 # Important Prefix
 
-You can prefix any utility classes with `!` to make them as `!important`. This could be very useful when you want to override previous styling rules for that specific property.
+You can prefix any utility classes with `!` to set them as `!important`. This could be very useful when you want to override previous styling rules for a specific property.
 
 ```css
 !text-green-300

--- a/features/index.md
+++ b/features/index.md
@@ -4,7 +4,7 @@
 
 # Features
 
-[Windi CSS] is fully compatible with [Tailwind CSS] v2. On top of that, we have many additional features that boost your workflow further and open up much more possibilities.
+[Windi CSS] is fully compatible with [Tailwind CSS] v2. On top of that, we have many additional features that boost your workflow further and open up many more possibilities.
 
 ## Value Auto-infer
 
@@ -26,7 +26,7 @@ Use arbitrary values in your classes and generate corresponding styles.
 
 ## Variant Groups
 
-Apply utilities for the same variant by grouping them with parenthesis.
+Apply utilities tp the same variant by grouping them with parentheses.
 
 ```html
 <div class="bg-white dark:hover:(bg-gray-800 font-medium text-white)"/>
@@ -40,7 +40,7 @@ Apply utilities for the same variant by grouping them with parenthesis.
 
 ## Responsive Design
 
-Extended responsive breakpoints control.
+Extended responsive breakpoint control.
 
 ```html
 <div class="p-1 md:p-2 <lg:p-3"></div>
@@ -50,7 +50,7 @@ Extended responsive breakpoints control.
 
 ## Important Prefix
 
-Prefix any utility classes with `!` to make them as `!important`.
+Prefix any utility classes with `!` to set them as `!important`.
 
 ```html
 <div class="text-red-400 !text-green-300">Green</div>
@@ -60,7 +60,7 @@ Prefix any utility classes with `!` to make them as `!important`.
 
 ## Shortcuts
 
-Create components and utilities quickly and reusable.
+Quickly combine utilities to create reusable components.
 
 ```js windi.config.js
 export default {

--- a/features/index.md
+++ b/features/index.md
@@ -26,7 +26,7 @@ Use arbitrary values in your classes and generate corresponding styles.
 
 ## Variant Groups
 
-Apply utilities tp the same variant by grouping them with parentheses.
+Apply utilities to the same variant by grouping them with parentheses.
 
 ```html
 <div class="bg-white dark:hover:(bg-gray-800 font-medium text-white)"/>

--- a/features/responsive-design.md
+++ b/features/responsive-design.md
@@ -1,6 +1,6 @@
 # Responsive Design
 
-Doing [Responsive Design](https://en.wikipedia.org/wiki/Responsive_web_design) in Windi CSS is effortless. By simply adding variant prefixes like `md:` or `lg:` to the utility you want to use. The corresponding media query will be generated automatically. Try it yourself using the playground below:
+Doing [Responsive Design](https://en.wikipedia.org/wiki/Responsive_web_design) in Windi CSS is effortless. By simply adding variant prefixes like `md:` or `lg:` to the utility you want to use, the corresponding media query will be generated automatically. Try it yourself using the playground below:
 
 <InlinePlayground :input="'p-1 lg:p-2'" :showCSS="true" :showPreview="false"/>
 
@@ -10,11 +10,11 @@ When you want to apply a breakpoint variant to multiple utilities, in Windi CSS 
 
 ## Custom Range
 
-By default, Windi CSS's breakpoints is designed as Mobile First. 
+By default, Windi CSS's breakpoints are designed as Mobile First. 
 
 This means unprefixed utilities (like `p-1`) take effect on all screen sizes, while prefixed utilities (like `md:p-2`) only take effect at the **specified breakpoint and above**.
 
-We also provided the ability to have more controls over the query range by adding the `<` and `@` prefix:
+We also provided the ability to have more control over the query range by adding the `<` and `@` prefixes:
 
 ```bash
 lg  => greater or equal than this breakpoint

--- a/features/rtl.md
+++ b/features/rtl.md
@@ -2,13 +2,13 @@
 
 Windi CSS has out-of-box RTL support with zero configuration from `v2.5.4`.
 
-By prefixing the `rtl:` variant to the utilities, they will only apply when RTL is enabled.
+By prefixing the `rtl:` variant to utilities, they will only apply when RTL is enabled.
 
 <!-- With the following example, the `Preview` text will be `text-right` and `text-red-400` on the RTL. Try play with it: -->
 
 <!-- <InlinePlayground :input="'text-green-400 rtl:(text-right text-red-400)'" :showCSS="true" :showPreview="true" /> -->
 
-It's easy to enable RTL, you just need to apply `dir="rtl"` on the `html` element to make it affects.
+It's easy to enable RTL, you just need to apply `dir="rtl"` on the `html` element.
 
 ```html
 <html>

--- a/features/shortcuts.md
+++ b/features/shortcuts.md
@@ -1,8 +1,8 @@
 # Shortcuts
 
-It's quite common when you work on same set of utilities for multiple times. We provided this "shortcuts" feature allowing you to give the combinations of utilities names you can you use them everywhere inside your app without needing to duplicate yourself.
+It's quite common to get repetitive when you work on similar utility sets. We provide this "shortcuts" feature allowing you to give the combinations of utility names which you can reuse everywhere inside your app without needing to repeat yourself.
 
-By simply adding the `shortcuts` field to your configurations:
+Simply add the `shortcuts` field to your configuration:
 
 ```js windi.config.js
 export default {
@@ -29,7 +29,7 @@ export default {
   :enableConfig="true"
 />
 
-CSS-in-JS syntax is also supported for complex utility
+CSS-in-JS syntax is also supported for complex utilities:
 
 ```js windi.config.js
 export default {
@@ -71,4 +71,4 @@ export default {
 />
 
 
-The utility added by this configuration can also be directly wrapped with variant, such as sm:btn. The function of this feature is similar to the @apply directive, it will merge all utilities into one style.
+The utility added by this configuration can also be directly wrapped in variants, such as sm:btn. The purpose of this feature is similar to the `@apply` directive, it will merge all utilities into one style.

--- a/features/value-auto-infer.md
+++ b/features/value-auto-infer.md
@@ -1,6 +1,6 @@
 # Value Auto-infer
 
-Since Windi CSS will only generate the CSS utilities you use, it enables the possibility to use arbitrary value in your classes and generate coresponding styles based on the appropriate semantics.
+Since Windi CSS will only generate the CSS utilities you use, it enables you to use arbitrary values in your classes and generate corresponding styles based on the appropriate semantics.
 
 ```html
 <!-- sizes and positions -->
@@ -15,9 +15,9 @@ Since Windi CSS will only generate the CSS utilities you use, it enables the pos
 <div class="grid-cols-[auto,1fr,30px]"></div>
 ```
 
-This is useful when you want to opt-out your design system and have some fine-grain controls over some specific components. Both direct `p-5px` and explicitly escaping `p-[5px]` are supported.
+This is useful when you want to opt-out of your design system and have some fine-grain controls over some specific components. Both direct `p-5px` and explicitly escaping `p-[5px]` are supported.
 
-We also provided [an visual analyser](/features/analyzer) to give you an overview of all the utilities usages in your project and spot unwanted value escaping of your design system with ease. 
+We also provided [an visual analyser](/features/analyzer) to give you an overview of all the utility usages in your project and to spot unwanted value escaping of your design system with ease. 
 
 ## Numbers
 
@@ -40,7 +40,7 @@ p-{size} -> padding: {size};
 ## Fractions
 
 ```less
-w-{fraction} -> width: {fraction -> precent};
+w-{fraction} -> width: {fraction -> percent};
 ```
 
 <InlinePlayground :input="'w-9/12'" :showCSS="true" :showPreview="false"/>
@@ -63,7 +63,7 @@ border-hex-{hex} -> border-color: rgba(...);
 
 ## Variables
 
-You can even pass variable names, which is very useful in combination with css variables.
+You can even pass variable names, which is very useful in combination with CSS variables.
 
 ```css
 bg-${variableName}

--- a/features/variant-groups.md
+++ b/features/variant-groups.md
@@ -1,6 +1,6 @@
 # Variant Groups
 
-Apply utilities for the same variant by grouping them with parenthesis.
+Apply utilities for the same variant by grouping them with a parenthesis.
 
 ```html
 <div class="hover:(bg-gray-400 font-medium) bg-white font-light"/>

--- a/guide/migration.md
+++ b/guide/migration.md
@@ -3,9 +3,9 @@
 
 # Migrate from Tailwind CSS
 
-## Package 
+## Packages 
 
-Some of your dependencies are no longer required. You can remove them if they were needed only for Tailwind CSS.
+Some of your dependencies are no longer required. You can remove them from your `package.json` if they were only needed for Tailwind CSS.
 
 ```diff package.json
 - "tailwindcss": "*",
@@ -16,7 +16,7 @@ Some of your dependencies are no longer required. You can remove them if they we
 
 ## Base Styles
 
-You can now remove the Tailwind CSS imports from your css entry.
+You can now remove the Tailwind CSS imports from your CSS entry.
 
 ```diff
 - @import 'tailwindcss/base';


### PR DESCRIPTION
this affects the sections:
- Guide
- Features

but not the section `Integrations`.

As I'm not a native speaker I only made changes where I felt confident enough. I also encountered two different spellings of "analyzer"/"analyser" whereas it would be good to keep the spelling uniform (helpful when running a text search). "Analyzer" is American English and probably more common.
I recommend squash merging due to the many individual commits :wink: 