### PR TITLE
fix: typo in zinc

### DIFF
--- a/posts/v34.md
+++ b/posts/v34.md
@@ -7,7 +7,7 @@ This is a summary version that summarizes the improvements and added features fr
 v3.4.0 added the following new colors:
 
 - `slate`
-- `zink`
+- `zinc`
 - `neutral`
 - `stone`
 


### PR DESCRIPTION
Should be `zinc`

There's a warning: https://github.com/windicss/windicss/blob/67802fe9af47ebcbebd5c5ee4e5cefc740e39506/src/config/colors.ts#L355