### PR TITLE
docs: fix typo

### DIFF
--- a/integrations/nuxt.md
+++ b/integrations/nuxt.md
@@ -73,7 +73,7 @@ By default, we scan your source code statically and find all the usages of the u
 <div :class="{ ['p-'+size]: true}">
 ```
 
-For that, you will need to specify the possible combinations in the `safelist` options of `webpack.config.js`.
+For that, you will need to specify the possible combinations in the `safelist` options of `windi.config.js`.
 
 ```ts windi.config.ts
 import { defineConfig } from 'windicss/helpers'


### PR DESCRIPTION
On the Nuxt integration page, rename `webpack.config.js` to `windi.config.js`.