### PR TITLE
docs: add info about typography plugin settings

### DIFF
--- a/plugins/official/typography.md
+++ b/plugins/official/typography.md
@@ -81,7 +81,16 @@ export default {
     },
   },
   plugins: [
-    require('windicss/plugin/typography'),
+    require('windicss/plugin/typography')({
+      // Turns text color to light, when dark mode enabled. Default = false
+      darkMode: true,
+      // Right-to-left mode (e.g. for Arabic, Uyghur languages). Default = false
+      rtl: true,
+      // Classname for typography plugin. Default = 'prose'
+      className: 'my-prose',
+      // Additional modifiers
+      modifiers: ['sm', 'lg'],
+    }),
     // ...
   ],
 }

--- a/plugins/official/typography.md
+++ b/plugins/official/typography.md
@@ -83,7 +83,7 @@ export default {
   plugins: [
     require('windicss/plugin/typography')({
       // Turns text color to light, when dark mode enabled. Default = false
-      darkMode: true,
+      dark: true,
       // Right-to-left mode (e.g. for Arabic, Uyghur languages). Default = false
       rtl: true,
       // Classname for typography plugin. Default = 'prose'


### PR DESCRIPTION
In https://github.com/windicss/windicss/issues/290, the lack of documentation was mentioned and I've also stumbled upon this when building my blog. So I think adding info about this plugin settings should be a good idea.