### PR TITLE
docs: Changed the Property nuxt config  for nuxt 3.

### DIFF
--- a/integrations/nuxt.md
+++ b/integrations/nuxt.md
@@ -24,12 +24,13 @@ export default {
 ```
 
 ### Nuxt 3
+note: `buildModules` is no longer needed in Nuxt 3 and Nuxt Bridge; all modules should be added to modules instead.
 
 ```js nuxt.config.js
 import { defineNuxtConfig } from 'nuxt3'
 
 export default defineNuxtConfig({
-  buildModules: [
+  modules: [
     'nuxt-windicss',
   ],
 })


### PR DESCRIPTION
Change the property from `buildModules` to `modules` because. `buildModules` is no longer needed in Nuxt 3 and Nuxt Bridge. All modules should be added to `modules` instead.