### PR TITLE
Update vue-cli.md

### DIFF
--- a/integrations/vue-cli.md
+++ b/integrations/vue-cli.md
@@ -80,7 +80,7 @@ export default {
 
 #### Disable Preflight
 
-_ngridsome.config.js_
+_vue.config.js_
 
 ```js
 module.exports = {


### PR DESCRIPTION
Made changes in the instructions to integrate WindiCSS with Vue. There is a Typo error, should be *vue.config.js* instead of *ngridsome.config.js*.