### PR TITLE
docs: update defineNuxtConfig import

### DIFF
--- a/integrations/nuxt.md
+++ b/integrations/nuxt.md
@@ -27,7 +27,7 @@ export default {
 note: `buildModules` is no longer needed in Nuxt 3 and Nuxt Bridge; all modules should be added to modules instead.
 
 ```js nuxt.config.js
-import { defineNuxtConfig } from 'nuxt3'
+import { defineNuxtConfig } from 'nuxt/config'
 
 export default defineNuxtConfig({
   modules: [


### PR DESCRIPTION
```js
import { defineNuxtConfig } from 'nuxt3'
```
no longer works and previously had a deprecation message.